### PR TITLE
Reduce zxing dependency in order to fix build issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ protobuf {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'me.dm7.barcodescanner:zxing:1.9.13'
+    implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
     api 'com.google.android.material:material:1.1.0'
 }


### PR DESCRIPTION
The 1.9.13 version no longer seems to exist in a [remote repository](https://mvnrepository.com/artifact/me.dm7.barcodescanner/zxing), at least any that I, or gradle, can easily find. They were stored in jCenter, which is deprecated, but now appear to be gone. The artifacts 404.

Looking at the [github](https://github.com/dm77/barcodescanner), it seems there aren't any significant features added after 1.9.8 that are important. So I'm hoping the solution can be as simple as dropping down to this version. 

I'm trying to build the Android version of Kalium and encountering build issues with finding this transitive dependency.

---

Related: https://github.com/BananoCoin/kalium_wallet_flutter/pull/57